### PR TITLE
audio: Fix order of destruction

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -98,8 +98,8 @@ void init() {
 }
 
 void destroy() {
-    ma_engine_uninit(&engine);
     SDL_CloseAudioDevice(device);
+    ma_engine_uninit(&engine);
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 


### PR DESCRIPTION
The audio device needs to be stopped before attempting to bring down the miniaudio engine.